### PR TITLE
Avoid memory leaks with 2+ comments

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -233,6 +233,9 @@ static int read_param(FILE* file, y4mFile_t* y4mfile)
         {
             char* comment_string = malloc(sizeof(char) * (strlen(tmp_string) + 1));
             strcpy(comment_string, tmp_string);
+            // do not leak memory with 2+ comments
+            if (y4mfile->comment != NULL)
+                free(y4mfile->comment);
             y4mfile->comment = comment_string;
         }
         return retval;


### PR DESCRIPTION
Parser assumes 1 only comment.

ffmpeg produces 2x comments by default.

Tested:
```
$ head -c 15000 /dev/zero > green.100x100.nv12.yuv
$ ffmpeg -y -f rawvideo -pixel_format nv12 -s 100x100 -i green.100x100.nv12.yuv -pix_fmt yuv420p green.100x100.yuv420p.y4m
...
$ head -2 green.100x100.yuv420p.y4m
YUV4MPEG2 W100 H100 F25:1 Ip A0:0 C420jpeg XYSCSS=420JPEG XCOLORRANGE=LIMITED
FRAME
```

Then checked with valgrind that there are no leaks after the fix.